### PR TITLE
feat: Added getter to (ICONS) for getResultLabel config.

### DIFF
--- a/yearzero-dice.js
+++ b/yearzero-dice.js
@@ -969,7 +969,7 @@ YearZeroDie.MODIFIERS = mergeObject(
 export class BaseDie extends YearZeroDie {
   /** @override */
   static getResultLabel(result) {
-    return CONFIG.YZUR.DICE.ICONS[CONFIG.YZUR.game].base[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('base', result);
   }
 }
 BaseDie.TYPE = 'base';
@@ -983,7 +983,7 @@ BaseDie.LOCKED_VALUES = [1, 6];
 export class SkillDie extends YearZeroDie {
   /** @override */
   static getResultLabel(result) {
-    return CONFIG.YZUR.DICE.ICONS[CONFIG.YZUR.game].skill[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('skill', result);
   }
 }
 SkillDie.TYPE = 'skill';
@@ -996,7 +996,7 @@ SkillDie.DENOMINATION = 's';
 export class GearDie extends YearZeroDie {
   /** @override */
   static getResultLabel(result) {
-    return CONFIG.YZUR.DICE.ICONS[CONFIG.YZUR.game].gear[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('gear', result);
   }
 }
 GearDie.TYPE = 'gear';
@@ -1017,7 +1017,7 @@ export class NegativeDie extends SkillDie {
   }
   /** @override */
   static getResultLabel(result) {
-    return CONFIG.YZUR.DICE.ICONS[CONFIG.YZUR.game].neg[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('neg', result);
   }
 }
 NegativeDie.TYPE = 'neg';
@@ -1032,7 +1032,7 @@ NegativeDie.DENOMINATION = 'n';
 export class StressDie extends YearZeroDie {
   /** @override */
   static getResultLabel(result) {
-    return CONFIG.YZUR.DICE.ICONS.alien.stress[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('stress', result);
   }
 }
 StressDie.TYPE = 'stress';
@@ -1058,7 +1058,7 @@ export class ArtifactDie extends SkillDie {
   /** @override */
   static getResultLabel(result) {
     // Must be overriden because it extends SkillDie.
-    return CONFIG.YZUR.DICE.ICONS.fbl.arto[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('arto', result);
   }
 }
 ArtifactDie.TYPE = 'arto';
@@ -1098,7 +1098,7 @@ D12ArtifactDie.DENOMINATION = '12';
 export class TwilightDie extends ArtifactDie {
   /** @override */
   static getResultLabel(result) {
-    return CONFIG.YZUR.DICE.ICONS.t2k.base[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('base', result);
   }
 }
 TwilightDie.TYPE = 'base';
@@ -1147,7 +1147,7 @@ export class AmmoDie extends YearZeroDie {
   get hit() { return this.count(6);}
   /** @override */
   static getResultLabel(result) {
-    return CONFIG.YZUR.DICE.ICONS.t2k.ammo[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('ammo', result);
   }
 }
 AmmoDie.TYPE = 'ammo';
@@ -1169,7 +1169,7 @@ export class LocationDie extends Die {
   }
   /** @override */
   static getResultLabel(result) {
-    return CONFIG.YZUR.DICE.ICONS.t2k.loc[result];
+    return CONFIG.YZUR.DICE.ICONS.getLabel('loc', result);
   }
 }
 LocationDie.TYPE = 'loc';
@@ -1211,6 +1211,9 @@ const YZUR = {
       'loc': LocationDie,
     },
     ICONS: {
+      getLabel: function(type, result) {
+        return this[YZUR.game][type][result];
+      },
       myz: {
         base: {
           '1': '☣',

--- a/yearzero-dice.js
+++ b/yearzero-dice.js
@@ -1055,11 +1055,6 @@ export class ArtifactDie extends SkillDie {
     this.results[this.results.length - 1] = roll;
     return roll;
   }
-  /** @override */
-  static getResultLabel(result) {
-    // Must be overriden because it extends SkillDie.
-    return CONFIG.YZUR.DICE.ICONS.getLabel('arto', result);
-  }
 }
 ArtifactDie.TYPE = 'arto';
 ArtifactDie.SUCCESS_TABLE = [null, 0, 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4];
@@ -1070,6 +1065,11 @@ export class D8ArtifactDie extends ArtifactDie {
     termData.faces = 8;
     super(termData);
   }
+  /** @override */
+  static getResultLabel(result) {
+    // Must be overriden because it extends SkillDie.
+    return CONFIG.YZUR.DICE.ICONS.getLabel('d8', result);
+  }
 }
 D8ArtifactDie.DENOMINATION = '8';
 
@@ -1078,6 +1078,11 @@ export class D10ArtifactDie extends ArtifactDie {
     termData.faces = 10;
     super(termData);
   }
+  /** @override */
+  static getResultLabel(result) {
+    // Must be overriden because it extends SkillDie.
+    return CONFIG.YZUR.DICE.ICONS.getLabel('d10', result);
+  }
 }
 D10ArtifactDie.DENOMINATION = '10';
 
@@ -1085,6 +1090,11 @@ export class D12ArtifactDie extends ArtifactDie {
   constructor(termData) {
     termData.faces = 12;
     super(termData);
+  }
+  /** @override */
+  static getResultLabel(result) {
+    // Must be overriden because it extends SkillDie.
+    return CONFIG.YZUR.DICE.ICONS.getLabel('d12', result);
   }
 }
 D12ArtifactDie.DENOMINATION = '12';
@@ -1212,6 +1222,8 @@ const YZUR = {
     },
     ICONS: {
       getLabel: function(type, result) {
+        const arto = ['d8', 'd10', 'd12'];
+        if (arto.includes(type)) type = 'arto';
         return this[YZUR.game][type][result];
       },
       myz: {


### PR DESCRIPTION
This commit facilitates local overriding of the way getResultLabel fetches ICONS,
from the ICONS config.

By doing it this way a local extension of the config can easily define
their own structure in the ICONS config.

e.g. it would allow for something like this:
```js
getLabel (type, result) =>  `<img src="/img/${ type }-${ result }.jpg" />`
```