### PR TITLE
Fix push button on floating dice chat card

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ await roll.push({ async: true });
 Add a listener to the button in the chat to get the roll and push it. See example below.
 
 ```js
-Hooks.on('renderChatLog', (app, html, data) => {
+Hooks.on('renderChatMessageHTML', (app, html, data) => {
   html.on('click', '.dice-button.push', _onPush);
 });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -274,7 +274,7 @@ await roll.push({ async: true });
 </code></pre>
 <h3>Push from the Chat</h3>
 <p>Add a listener to the button in the chat to get the roll and push it. See example below.</p>
-<pre class="prettyprint source lang-js"><code>Hooks.on('renderChatLog', (app, html, data) => {
+<pre class="prettyprint source lang-js"><code>Hooks.on('renderChatMessageHTML', (app, html, data) => {
   html.on('click', '.dice-button.push', _onPush);
 });
 

--- a/foundry-year-zero-roller.js
+++ b/foundry-year-zero-roller.js
@@ -25,7 +25,7 @@ Hooks.once('ready', function () {
   console.warn('YZ Roller Tester | READY!');
 });
 
-Hooks.on('renderChatLog', (app, html, _data) => {
+Hooks.on('renderChatMessageHTML', (app, html, _data) => {
   $(html).on('click', '.dice-button.push', _onPush);
 });
 


### PR DESCRIPTION
The chat floating card displays roll results with push and accept buttons, but it doesn't handle button clicks. This PR resolves this issue.

The buttons work well in the chat windows, so the renderChatLog event occurs only for this case, but the renderChatMessageHTML works in both cases. I will propose a PR on YZUR.

I was not able to test this module properly, but I have tested my changes in the Blade Runner system (https://github.com/fvtt-fria-ligan/blade-runner-foundry-vtt/pull/62).

<img width="441" height="348" alt="image" src="https://github.com/user-attachments/assets/b543ee9b-52d9-40e6-a6f0-c3429f97f914" />
