### PR TITLE
✨ Add dice to Foundry Dice Configuration

### DIFF
--- a/src/YearZeroRollManager.js
+++ b/src/YearZeroRollManager.js
@@ -147,6 +147,7 @@ export default class YearZeroRollManager {
       console.log(`YZUR | Die Registration: "${deno}" with ${cls.name}.`);
     }
     CONFIG.Dice.terms[deno] = cls;
+    CONFIG.Dice.fulfillment.dice[deno] = {label: `d${deno}`, icon: "<i class=\"fa-solid fa-dice\"></i>"};
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
This allows people to select manual modes for the dices used on the Year Zero Dice Roller