### PR TITLE
✨ Remove parenthesis from formula when not necessary

### DIFF
--- a/src/YearZeroRoll.js
+++ b/src/YearZeroRoll.js
@@ -276,6 +276,21 @@ export default class YearZeroRoll extends Roll {
     return new YearZeroRoll(formula, data, options);
   }
 
+  /**
+   * Replaces the `(digit)` patterns in a formula after data replacement.
+   * See https://github.com/fvtt-fria-ligan/blade-runner-foundry-vtt/issues/65 for more information.
+   * @override
+   */
+  static replaceFormulaData(formula, data, {missing, warn=false}={}) {
+    const replaced = super.replaceFormulaData(formula, data, {missing, warn});
+
+    const regex = new RegExp('\\((\\d*)\\)', 'gm')
+    const subst = `$1`;
+    const result = replaced.replace(regex, subst);
+
+    return result;
+  }
+
   /* -------------------------------------------- */
 
   /**


### PR DESCRIPTION
Fix fvtt-fria-ligan/blade-runner-foundry-vtt#65: inline rolls are something like `1d(@agi)p@maxPush`, which will cause issues as the `1d(10)p0` will not be recognized as the same as `1d10p0` (because of the parenthesis). Given that, we are introducing an override of the `replaceFormulaData` that calls the super and then removes parenthesis that are not necessary anymore, converting `1d(10)p0` to `1d10p0`.