### PR TITLE
ci: Fix set-output deprecation warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,7 @@ jobs:
 
       - name: 🏷️ Get Version Tag
         id: tag_name
-        run: |
-          echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
-        shell: bash
+        run: echo "current_version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: 📜 Get Changelog Entry
         id: changelog_reader


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#grouping-log-lines